### PR TITLE
use new image service

### DIFF
--- a/app/dev/client/assets/js/src/modules/origami/origami-businesscard.js
+++ b/app/dev/client/assets/js/src/modules/origami/origami-businesscard.js
@@ -4,7 +4,7 @@ export class OrigamiBusinesscard {
         this.lastName = 'Kellaway';
         this.email = 'lucy.kellaway@ft.com';
         this.ftComment = 'http://www.ft.com/comment/lucy-kellaway';
-        this.imageUrl = 'http://image.webservices.ft.com/v1/images/raw/fthead:lucy-kellaway?source=docs&format=png&width=60';
+        this.imageUrl = 'https://www.ft.com/__origami/service/image/v2/images/raw/fthead:lucy-kellaway?source=docs&format=png&width=60';
         this.twitterUrl = '//twitter.com/LucyKellaway';
         this.twitterId = '@LucyKellaway';
         this.age = '54';

--- a/app/dev/client/assets/js/src/modules/origami/origami-promobox.js
+++ b/app/dev/client/assets/js/src/modules/origami/origami-promobox.js
@@ -1,7 +1,7 @@
 export class OrigamiPromobox {
     constructor() {
         this.title = 'Repeating work again, again, again';
-        this.imageUrl = 'http://image.webservices.ft.com/v1/images/raw/http://origami.ft.com/img/devices.png?width=167&source=docs';
+        this.imageUrl = 'https://www.ft.com/__origami/service/image/v2/images/raw/http://origami.ft.com/img/devices.png?width=167&source=docs';
         this.text = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam erat justo, placerat sed sem a, mattis semper lectus. Vestibulum molestie sem eget pulvinar volutpat. Donec nulla enim, scelerisque at dictum placerat, elementum at sem. Duis ut nisi at risus eleifend euismod. Curabitur eget velit nulla. In ac ullamcorper nisl, ut iaculis libero. Integer pharetra faucibus elit, at molestie tortor eleifend at.';
     }
 }

--- a/app/dev/client/assets/sass/modules/related-content.scss
+++ b/app/dev/client/assets/sass/modules/related-content.scss
@@ -5,7 +5,7 @@
     margin-right: -40px;
     .related-content-header {
         position: relative;
-        background: transparent url("https://next-geebee.ft.com/image/v1/images/raw/http%3a%2f%2fnext-geebee.ft.com%2fassets%2fbackgrounds%2ffront-page-section-header-v2.svg?source=next&format=svg&tint=000000,000000") repeat scroll 0 0;
+        background: transparent url("https://www.ft.com/__origami/service/image/v2/images/raw/http%3a%2f%2fnext-geebee.ft.com%2fassets%2fbackgrounds%2ffront-page-section-header-v2.svg?source=next&format=svg&tint=000000,000000") repeat scroll 0 0;
         width: 100%;
         overflow: auto;
         margin: 24px 0 12px 0;


### PR DESCRIPTION
We launched the new image service 6 days ago, I'm currently going around FT projects and helping them migrate to it.

The new Image Service includes a lot of improvements:
- The application is multi-region with failover
- We use stale-on-error and stale-while-revalidate cache extensions to ensure users get stale content if the application errors or has to revalidate an image
- We serve much smaller WebP and JPEG XR images to supported browsers
- We’ve seen a reduction in file size for a large number of image requests
- We’re now serving images over H2